### PR TITLE
Small Fixes

### DIFF
--- a/lib/build_option_normalizer.js
+++ b/lib/build_option_normalizer.js
@@ -3,13 +3,14 @@ var Logger                  = require('./logger_decorator')
 
 var QueryStringParser       = require('./query_string_parser')
 var TruffleConfigLocator    = require('./truffle_config_locator')
+var TruffleConfig           = require('truffle/lib/config.js');
 
 var BuildOptionNormalizer = {
   normalize: function(buildOpts, query) {
     var truffleConfig = TruffleConfigLocator.find()
 
     if(truffleConfig) {
-      var config = require(truffleConfig)
+      var config = TruffleConfig.load(truffleConfig)
       merge(buildOpts, config)
     }
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   "devDependencies": {
     "ether-pudding": "^3.1.2",
     "findup": "^0.1.5",
-    "temp": "^0.8.3",
     "truffle": "^2.0.8",
     "web3": "^0.17.0-alpha",
     "lodash.merge": "^4.6.0"
   },
   "dependencies": {
+    "temp": "^0.8.3",
     "chalk": "^1.1.3",
     "find-up": "^1.1.2"
   }


### PR DESCRIPTION
1. `temp` is a production dependency, and my webpack run was erroring without it.
2. use the `TruffleConfig` object to infer missing/default config values
