### PR TITLE
Use same build directory as truffle

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const fallbackBuildDir = '.truffle-solidity-loader'
+
 /* External Module Dependencies */
 var TruffleContractCompiler = require('truffle/lib/contracts')
 var TruffleContractMigrator = require('truffle/lib/migrate')
@@ -39,9 +41,14 @@ function returnContractAsSource (filePath, compilationFinished) {
 var isCompilingContracts = false
 
 module.exports = function (source) {
+  var buildOpts = {}
+  buildOpts.logger = Logger
+  buildOpts = BuildOptionNormalizer.normalize(buildOpts, this.query)
+
   this.cacheable && this.cacheable()
 
-  var scratchPath = new ScratchDir()
+  var buildDir = buildOpts.build_directory ? buildOpts.build_directory : fallbackBuildDir
+  var scratchPath = new ScratchDir(buildDir, this.context)
   scratchPath.createIfMissing()
 
   var buildPath = scratchPath.path()
@@ -63,10 +70,6 @@ module.exports = function (source) {
       fs.unlinkSync(compiledContractPath)
     }
   }.bind(this))
-
-  var buildOpts = {}
-  buildOpts.logger = Logger
-  buildOpts = BuildOptionNormalizer.normalize(buildOpts, this.query)
 
   function waitForContractCompilation () {
     setTimeout(function () {

--- a/lib/scratch_dir.js
+++ b/lib/scratch_dir.js
@@ -4,7 +4,10 @@ var fs                      = require('fs')
 /* ScratchDir - Handles the creation and path resolution of the
  * webpack loader build artifacts directory.
  */
-var ScratchDir = function ScratchDir () { }
+var ScratchDir = function ScratchDir (scratchDir, context) {
+  this.scratchDir = scratchDir
+  this.context = context
+}
 
 ScratchDir.prototype = {
   createIfMissing: function() {
@@ -17,10 +20,27 @@ ScratchDir.prototype = {
     return this.isDirSync( this.path() )
   },
 
+  contractPath: function() {
+    var result = ''
+    var cwd = process.cwd()
+    var contextHead = this.context.slice(0, cwd.length)
+    var contextTail = this.context.slice(cwd.length)
+    var explodedTail = contextTail.split(path.sep)
+    var contextTailHasLeadingSlash = explodedTail[0] === ''
+    var contextIsSubdirOfCwd = (contextHead === cwd)
+    if(contextIsSubdirOfCwd) {
+      if(contextTailHasLeadingSlash) {
+        result = explodedTail.slice(1).join(path.sep)
+      } else {
+        result = explodedTail.join(path.sep)
+      }
+    }
+    return result;
+  },
+
   path: function() {
     var cwd = process.cwd()
-    var scratchDir = '.truffle-solidity-loader'
-    return path.resolve( cwd, scratchDir)
+    return path.resolve( cwd, this.scratchDir, this.contractPath())
   },
 
   isDirSync: function(aPath) {


### PR DESCRIPTION
Perhaps this is just an oversight on my part or there is a good reason for this behavior that I haven't considered (I wouldn't be surprised), but it seems to me that this webpack loader deploys to a separate build location than truffle does - making it unnecessarily difficult to use truffle scripts along with dapps deployed with webpack. In my case, I use truffle-solidity-loader to deploy a development dapp which uses react - and I have built a seed script which creates sample data for development which can be run with `$ truffle exec seed.js`. Without a modification such as the one presented in this PR, the seed data is placed on a separate deployed contract and is quite useless.

I am opening this PR in case it might be a useful contribution. I realize it may not be.

Details:

Uses the truffle.js config property `build_directory` (if available) instead of `.truffle-solidity-loader`. Automatically determines the path to the contracts relative to the project, and places the compiled contracts in the same path relative to the build directory.

The result is that the compiled contracts are placed in the same place truffle places them,  preventing the situation when using webpack along with truffle commands (migrate, console, exec, etc.) where 2 build directories (and thus 2 separate deployments) get created.